### PR TITLE
Saturation clouds flare masking only

### DIFF
--- a/ghg_process.py
+++ b/ghg_process.py
@@ -22,8 +22,7 @@ import subprocess
 
 import target_generation
 import parallel_mf
-#import local_surface_control_simple
-import local_surface_control
+import local_surface_control_simple
 import scale
 import logging
 from spectral.io import envi
@@ -159,11 +158,11 @@ def main(input_args=None):
         parallel_mf.main(subargs)
 
     if (os.path.isfile(co2_mf_refined_file) is False or args.overwrite) and args.co2:
-        local_surface_control.main([co2_mf_file, args.radiance_file, args.loc_file, irr_file, co2_mf_refined_file, '--type', 'co2'])
-        #local_surface_control_simple.main([co2_mf_file, args.radiance_file, args.mask_file, co2_mf_refined_file, '--type', 'co2'])
+        #local_surface_control.main([co2_mf_file, args.radiance_file, args.loc_file, irr_file, co2_mf_refined_file, '--type', 'co2'])
+        local_surface_control_simple.main([co2_mf_file, args.radiance_file, args.mask_file, co2_mf_refined_file, '--type', 'co2'])
     if os.path.isfile(ch4_mf_refined_file) is False or args.overwrite:
-        local_surface_control.main([ch4_mf_file, args.radiance_file, args.loc_file, irr_file, ch4_mf_refined_file, '--type', 'ch4'])
-        #local_surface_control_simple.main([ch4_mf_file, args.radiance_file, args.mask_file, ch4_mf_refined_file, '--type', 'ch4'])
+        #local_surface_control.main([ch4_mf_file, args.radiance_file, args.loc_file, irr_file, ch4_mf_refined_file, '--type', 'ch4'])
+        local_surface_control_simple.main([ch4_mf_file, args.radiance_file, args.mask_file, ch4_mf_refined_file, '--type', 'ch4'])
 
     if (os.path.isfile(co2_mf_refined_ort_file) is False or args.overwrite) and args.co2:
         subprocess.call(f'python apply_glt.py {args.glt_file} {co2_mf_refined_file} {co2_mf_refined_ort_file}',shell=True)

--- a/ghg_process.py
+++ b/ghg_process.py
@@ -39,7 +39,7 @@ def main(input_args=None):
     parser.add_argument('obs_file', type=str,  help='path to observation image')   
     parser.add_argument('loc_file', type=str,  help='path to location image')   
     parser.add_argument('glt_file', type=str,  help='path to glt image')   
-    parser.add_argument('mask_file', type=str,  help='path to mask image')   
+    parser.add_argument('l1b_bandmask_file', type=str,  help='path to l1b bandmask image')   
     parser.add_argument('l2a_mask_file', type=str,  help='path to l2a mask image')   
     parser.add_argument('output_base', type=str,  help='output basepath for output image')    
     parser.add_argument('--state_subs', type=str, default=None,  help='state file from OE retrieval')    
@@ -145,7 +145,7 @@ def main(input_args=None):
 
 
     if (os.path.isfile(co2_mf_file) is False or args.overwrite) and args.co2:
-        subargs = [args.radiance_file, co2_target_file, co2_mf_file]
+        subargs = [args.radiance_file, co2_target_file, co2_mf_file, args.l1b_bandmask_file, args.l2a_mask_file]
         if args.ace_filter:
             subargs.append('--use_ace_filter')
         parallel_mf.main(subargs)
@@ -154,17 +154,17 @@ def main(input_args=None):
     print(ch4_mf_file)
     if os.path.isfile(ch4_mf_file) is False or args.overwrite:
         print('starting parallel mf')
-        subargs = [args.radiance_file, ch4_target_file, ch4_mf_file, args.mask_file, args.l2a_mask_file]
+        subargs = [args.radiance_file, ch4_target_file, ch4_mf_file, args.l1b_bandmask_file, args.l2a_mask_file]
         if args.ace_filter:
             subargs.append('--use_ace_filter')
         parallel_mf.main(subargs)
 
     if (os.path.isfile(co2_mf_refined_file) is False or args.overwrite) and args.co2:
         #local_surface_control.main([co2_mf_file, args.radiance_file, args.loc_file, irr_file, co2_mf_refined_file, '--type', 'co2'])
-        local_surface_control_simple.main([co2_mf_file, args.radiance_file, args.mask_file, co2_mf_refined_file, '--type', 'co2'])
+        local_surface_control_simple.main([co2_mf_file, args.radiance_file, args.l1b_bandmask_file, co2_mf_refined_file, '--type', 'co2'])
     if os.path.isfile(ch4_mf_refined_file) is False or args.overwrite:
         #local_surface_control.main([ch4_mf_file, args.radiance_file, args.loc_file, irr_file, ch4_mf_refined_file, '--type', 'ch4'])
-        local_surface_control_simple.main([ch4_mf_file, args.radiance_file, args.mask_file, ch4_mf_refined_file, '--type', 'ch4'])
+        local_surface_control_simple.main([ch4_mf_file, args.radiance_file, args.l1b_bandmask_file, ch4_mf_refined_file, '--type', 'ch4'])
 
     if (os.path.isfile(co2_mf_refined_ort_file) is False or args.overwrite) and args.co2:
         subprocess.call(f'python apply_glt.py {args.glt_file} {co2_mf_refined_file} {co2_mf_refined_ort_file}',shell=True)

--- a/ghg_process.py
+++ b/ghg_process.py
@@ -22,7 +22,8 @@ import subprocess
 
 import target_generation
 import parallel_mf
-import local_surface_control_simple
+#import local_surface_control_simple
+import local_surface_control
 import scale
 import logging
 from spectral.io import envi
@@ -151,17 +152,17 @@ def main(input_args=None):
     print(ch4_mf_file)
     if os.path.isfile(ch4_mf_file) is False or args.overwrite:
         print('starting parallel mf')
-        subargs = [args.radiance_file, ch4_target_file, ch4_mf_file]
+        subargs = [args.radiance_file, ch4_target_file, ch4_mf_file, args.mask_file]
         if args.ace_filter:
             subargs.append('--use_ace_filter')
         parallel_mf.main(subargs)
 
     if (os.path.isfile(co2_mf_refined_file) is False or args.overwrite) and args.co2:
-        #local_surface_control.main([co2_mf_file, args.radiance_file, args.loc_file, irr_file, co2_mf_refined_file, '--type', 'co2'])
-        local_surface_control_simple.main([co2_mf_file, args.radiance_file, args.mask_file, co2_mf_refined_file, '--type', 'co2'])
+        local_surface_control.main([co2_mf_file, args.radiance_file, args.loc_file, irr_file, co2_mf_refined_file, '--type', 'co2'])
+        #local_surface_control_simple.main([co2_mf_file, args.radiance_file, args.mask_file, co2_mf_refined_file, '--type', 'co2'])
     if os.path.isfile(ch4_mf_refined_file) is False or args.overwrite:
-        #local_surface_control.main([ch4_mf_file, args.radiance_file, args.loc_file, irr_file, ch4_mf_refined_file, '--type', 'ch4'])
-        local_surface_control_simple.main([ch4_mf_file, args.radiance_file, args.mask_file, ch4_mf_refined_file, '--type', 'ch4'])
+        local_surface_control.main([ch4_mf_file, args.radiance_file, args.loc_file, irr_file, ch4_mf_refined_file, '--type', 'ch4'])
+        #local_surface_control_simple.main([ch4_mf_file, args.radiance_file, args.mask_file, ch4_mf_refined_file, '--type', 'ch4'])
 
     if (os.path.isfile(co2_mf_refined_ort_file) is False or args.overwrite) and args.co2:
         subprocess.call(f'python apply_glt.py {args.glt_file} {co2_mf_refined_file} {co2_mf_refined_ort_file}',shell=True)

--- a/ghg_process.py
+++ b/ghg_process.py
@@ -41,6 +41,7 @@ def main(input_args=None):
     parser.add_argument('loc_file', type=str,  help='path to location image')   
     parser.add_argument('glt_file', type=str,  help='path to glt image')   
     parser.add_argument('mask_file', type=str,  help='path to mask image')   
+    parser.add_argument('l2a_mask_file', type=str,  help='path to l2a mask image')   
     parser.add_argument('output_base', type=str,  help='output basepath for output image')    
     parser.add_argument('--state_subs', type=str, default=None,  help='state file from OE retrieval')    
     parser.add_argument('--overwrite', action='store_true',  help='state file from OE retrieval')    
@@ -152,7 +153,7 @@ def main(input_args=None):
     print(ch4_mf_file)
     if os.path.isfile(ch4_mf_file) is False or args.overwrite:
         print('starting parallel mf')
-        subargs = [args.radiance_file, ch4_target_file, ch4_mf_file, args.mask_file]
+        subargs = [args.radiance_file, ch4_target_file, ch4_mf_file, args.mask_file, args.l2a_mask_file]
         if args.ace_filter:
             subargs.append('--use_ace_filter')
         parallel_mf.main(subargs)

--- a/parallel_mf.py
+++ b/parallel_mf.py
@@ -32,7 +32,6 @@ from utils import envi_header
 from sklearn.cluster import MiniBatchKMeans
 import ray
 import logging
-import pdb
 
 ppmscaling = 100000.0
 CH4_WL = [2137, 2493]

--- a/parallel_mf.py
+++ b/parallel_mf.py
@@ -25,6 +25,7 @@ from spectral.io import envi
 from os import makedirs
 from os.path import join as pathjoin, exists as pathexists
 import scipy
+import scipy.ndimage
 import numpy as np
 from utils import envi_header
 
@@ -57,6 +58,7 @@ def main(input_args=None):
     parser.add_argument('radiance_file', type=str,  metavar='INPUT', help='path to input image')   
     parser.add_argument('library', type=str,  metavar='LIBRARY', help='path to target library file')
     parser.add_argument('output', type=str,  metavar='OUTPUT', help='path for output image (mf ch4 ppm)')    
+    parser.add_argument('mask_file', type=str,  metavar='MASK_VILE', help='path to the band mask file')    
     args = parser.parse_args(input_args)
 
 
@@ -69,6 +71,13 @@ def main(input_args=None):
 
     baseoutfile = args.output 
     baseoutfilehdr = envi_header(baseoutfile)
+
+    bandmask_loaded = envi.open(envi_header(args.mask_file))[:,:,:]
+    bandmask_unpacked = np.unpackbits(bandmask_loaded, axis= -1)
+    mask_summed = np.sum(bandmask_unpacked, axis = -1)
+    mask_norm = mask_summed - np.min(mask_summed, axis = 0)
+    # True for pixels that should be used, False for those that are to be excluded
+    mask_dilated = scipy.ndimage.binary_dilation(mask_norm != 0, iterations = 10) < 1
 
     # columnwise spectral averaging function
     colavgfn = np.mean
@@ -181,7 +190,7 @@ def main(input_args=None):
     img_mm_id = ray.put(img_mm.copy())
     abscf_id = ray.put(abscf)
 
-    jobs = [mf_one_column.remote(col,img_mm_id, bgminsamp, outimg_shp, bgimg_shp, abscf_id, args) for col in np.arange(ncols)]
+    jobs = [mf_one_column.remote(col,img_mm_id, bgminsamp, outimg_shp, bgimg_shp, abscf_id, mask_dilated, args) for col in np.arange(ncols)]
     
     rreturn = [ray.get(jid) for jid in jobs]
     outimg_mm = outimg.open_memmap(interleave='source',writable=True)
@@ -330,7 +339,7 @@ def looshrinkage(I_zm,alphas,nll,n,I_reg=[]):
 
 
 @ray.remote
-def mf_one_column(col, img_mm, bgminsamp, outimg_mm_shape, bgimg_mm_shape, abscf, args):
+def mf_one_column(col, img_mm, bgminsamp, outimg_mm_shape, bgimg_mm_shape, abscf, mask_dilated, args):
 
 
     logging.basicConfig(format='%(levelname)s:%(asctime)s ||| %(message)s', level=args.loglevel,
@@ -415,9 +424,15 @@ def mf_one_column(col, img_mm, bgminsamp, outimg_mm_shape, bgimg_mm_shape, abscf
 
         # need to recompute mu and associated vars wrt this cluster
         Icol_ki = (Icol if bgmodes == 1 else Icol[kmask,:]).copy()     
+
+        # Create array without masked pixels for use in mean and covariance estimation only
+        Icol_ki_for_mu_C = Icol[mask_dilated[use,col], :].copy()
+        if bgmodes != 1:
+            kmask_mask = kmask[mask_dilated[use,col]]
+            Icol_ki_for_mu_C = Icol_ki_for_mu_C[kmask_mask,:].copy()
         
         Icol_sub = Icol_ki.copy()
-        mu = colavgfn(Icol_sub,axis=0)
+        mu = colavgfn(Icol_ki_for_mu_C,axis=0)
         # reinit model/modelfit here for each column/cluster instance
         if modelname == 'empirical':
             modelfit = lambda I_zm: cov(I_zm)
@@ -429,7 +444,8 @@ def mf_one_column(col, img_mm, bgminsamp, outimg_mm_shape, bgimg_mm_shape, abscf
             
         try:                            
             Icol_sub = Icol_sub-mu
-            Icol_model = modelfit(Icol_sub)
+            Icol_sub_for_mu_C = Icol_ki_for_mu_C - mu
+            Icol_model = modelfit(Icol_sub_for_mu_C)
             if modelname=='looshrinkage':
                 C,alphaidx = Icol_model
                 w = gaussian_window(C, 20)

--- a/parallel_mf.py
+++ b/parallel_mf.py
@@ -59,6 +59,7 @@ def main(input_args=None):
     parser.add_argument('library', type=str,  metavar='LIBRARY', help='path to target library file')
     parser.add_argument('output', type=str,  metavar='OUTPUT', help='path for output image (mf ch4 ppm)')    
     parser.add_argument('mask_file', type=str,  metavar='MASK_VILE', help='path to the band mask file')    
+    parser.add_argument('l2a_mask_file', type=str,  help='path to l2a mask image')   
     args = parser.parse_args(input_args)
 
 
@@ -77,7 +78,10 @@ def main(input_args=None):
     mask_summed = np.sum(bandmask_unpacked, axis = -1)
     mask_norm = mask_summed - np.min(mask_summed, axis = 0)
     # True for pixels that should be used, False for those that are to be excluded
-    mask_dilated = scipy.ndimage.binary_dilation(mask_norm != 0, iterations = 10) < 1
+    umask_dilated = scipy.ndimage.binary_dilation(mask_norm != 0, iterations = 10) < 1
+
+    # Clouds and water
+    l2a_mask = np.sum(envi.open(envi_header(args.l2a_mask_file)).open_memmap(interleave='bip')[...,:3],axis=-1) > 0
 
     # columnwise spectral averaging function
     colavgfn = np.mean
@@ -105,6 +109,15 @@ def main(input_args=None):
         sys.exit(0)
 
     img_mm = img.open_memmap(interleave='source',writeable=False)[:,active,:]
+
+    # Make flare mask
+    b270_idx = np.argwhere(np.array(active) == 270)[0][0]
+    hot = np.where(np.logical_and(img_mm[:,b270_idx,:] > 1.5, umask_dilated == True), 1., 0.)
+    hot_dilated = scipy.ndimage.uniform_filter(hot, [5,5]) > 0.01
+    umask_dilated = np.where(hot_dilated, False, umask_dilated)
+    
+    # Clouds and water
+    umask_dilated = np.where(l2a_mask, False, umask_dilated)
 
     # load the gas spectrum
     libdata = np.float64(np.loadtxt(args.library))
@@ -190,7 +203,7 @@ def main(input_args=None):
     img_mm_id = ray.put(img_mm.copy())
     abscf_id = ray.put(abscf)
 
-    jobs = [mf_one_column.remote(col,img_mm_id, bgminsamp, outimg_shp, bgimg_shp, abscf_id, mask_dilated, args) for col in np.arange(ncols)]
+    jobs = [mf_one_column.remote(col,img_mm_id, bgminsamp, outimg_shp, bgimg_shp, abscf_id, umask_dilated, args) for col in np.arange(ncols)]
     
     rreturn = [ray.get(jid) for jid in jobs]
     outimg_mm = outimg.open_memmap(interleave='source',writable=True)
@@ -339,7 +352,7 @@ def looshrinkage(I_zm,alphas,nll,n,I_reg=[]):
 
 
 @ray.remote
-def mf_one_column(col, img_mm, bgminsamp, outimg_mm_shape, bgimg_mm_shape, abscf, mask_dilated, args):
+def mf_one_column(col, img_mm, bgminsamp, outimg_mm_shape, bgimg_mm_shape, abscf, umask_dilated, args):
 
 
     logging.basicConfig(format='%(levelname)s:%(asctime)s ||| %(message)s', level=args.loglevel,
@@ -426,9 +439,9 @@ def mf_one_column(col, img_mm, bgminsamp, outimg_mm_shape, bgimg_mm_shape, abscf
         Icol_ki = (Icol if bgmodes == 1 else Icol[kmask,:]).copy()     
 
         # Create array without masked pixels for use in mean and covariance estimation only
-        Icol_ki_for_mu_C = Icol[mask_dilated[use,col], :].copy()
+        Icol_ki_for_mu_C = Icol[umask_dilated[use,col], :].copy()
         if bgmodes != 1:
-            kmask_mask = kmask[mask_dilated[use,col]]
+            kmask_mask = kmask[umask_dilated[use,col]]
             Icol_ki_for_mu_C = Icol_ki_for_mu_C[kmask_mask,:].copy()
         
         Icol_sub = Icol_ki.copy()

--- a/run_bulk_ghg.py
+++ b/run_bulk_ghg.py
@@ -41,7 +41,8 @@ def main(input_args=None):
     obs_files = [x.replace('rdn','obs') for x in rdn_files]
     loc_files = [x.replace('rdn','loc') for x in rdn_files]
     glt_files = [x.replace('rdn','glt') for x in rdn_files]
-    mask_files = [x.replace('l1b','l2a').replace('rdn','mask') for x in rdn_files]
+    l1b_bandmask_files = [x.replace('rdn','bandmask') for x in rdn_files]
+    l2a_mask_files = [x.replace('l1b','l2a').replace('rdn','mask') for x in rdn_files]
 
     state_files = [x.replace('l1b','l2a').replace('rdn','statesubs') for x in rdn_files]
     state_files = [x if os.path.isfile(x) else None for x in state_files]
@@ -56,7 +57,7 @@ def main(input_args=None):
 
       launch = os.path.isfile(ch4_mf_kmz_file) is False
       if os.path.isfile(ch4_mf_kmz_file) is False or (args.co2 and os.path.isfile(co2_mf_kmz_file) is False):
-        cmd_str=f'sbatch -N 1 -c 40 -p standard --mem=180G --wrap="python ghg_process.py {rdn_files[_r]} {obs_files[_r]} {loc_files[_r]} {glt_files[_r]} {mask_files[_r]} {out_files[_r]}'
+        cmd_str=f'sbatch -N 1 -c 40 -p standard --mem=180G --wrap="python ghg_process.py {rdn_files[_r]} {obs_files[_r]} {loc_files[_r]} {glt_files[_r]} {l1b_bandmask_files[_r]} {l2a_mask_files[_r]} {out_files[_r]}'
 
         if args.co2:
             cmd_str += ' --co2'

--- a/target_generation.py
+++ b/target_generation.py
@@ -24,7 +24,6 @@ import scipy.ndimage
 import argparse
 import spectral
 import h5py
-import pdb
 
 
 def check_param(value, min, max, name):
@@ -195,10 +194,6 @@ def generate_template_from_bands(centers, fwhm, params, dataset_loader, **kwargs
     :return template: the unit absorption spectum
     """
     # import scipy.stats
-
-    #params['water'] = 0.
-
-
     SCALING = 1e5
     centers = np.asarray(centers)
     fwhm = np.asarray(fwhm)
@@ -217,9 +212,6 @@ def generate_template_from_bands(centers, fwhm, params, dataset_loader, **kwargs
         kwargs.pop('concentrations')
     concentrations = np.asarray(kwargs.get(
         'concentrations', [0.0, 1000, 2000, 4000, 8000, 16000, 32000, 64000]))
-
-    #concentrations = [0., 100., 200., 400., 800., 1600., 3200., 6400.]
-
     rads, wave = generate_library(
         concentrations, dataset_fcn=dataset_loader, **params)
     # sigma = fwhm / ( 2 * sqrt( 2 * ln(2) ) )  ~=  fwhm / 2.355
@@ -240,10 +232,6 @@ def generate_template_from_bands(centers, fwhm, params, dataset_loader, **kwargs
     slope, _, _, _ = np.linalg.lstsq(
         np.stack((np.ones_like(concentrations), concentrations)).T, lograd, rcond=None)
     spectrum = slope[1, :] * SCALING
-
-    #st, en = 0,1
-    #spectrum = (rads[en,:] - rads[st,:]).dot(response) / (concentrations[en]-concentrations[st]) * SCALING
-
     target = np.stack((np.arange(1, spectrum.shape[0]+1), centers, spectrum)).T
     return target
 

--- a/target_generation.py
+++ b/target_generation.py
@@ -24,6 +24,7 @@ import scipy.ndimage
 import argparse
 import spectral
 import h5py
+import pdb
 
 
 def check_param(value, min, max, name):
@@ -194,6 +195,10 @@ def generate_template_from_bands(centers, fwhm, params, dataset_loader, **kwargs
     :return template: the unit absorption spectum
     """
     # import scipy.stats
+
+    #params['water'] = 0.
+
+
     SCALING = 1e5
     centers = np.asarray(centers)
     fwhm = np.asarray(fwhm)
@@ -212,6 +217,9 @@ def generate_template_from_bands(centers, fwhm, params, dataset_loader, **kwargs
         kwargs.pop('concentrations')
     concentrations = np.asarray(kwargs.get(
         'concentrations', [0.0, 1000, 2000, 4000, 8000, 16000, 32000, 64000]))
+
+    #concentrations = [0., 100., 200., 400., 800., 1600., 3200., 6400.]
+
     rads, wave = generate_library(
         concentrations, dataset_fcn=dataset_loader, **params)
     # sigma = fwhm / ( 2 * sqrt( 2 * ln(2) ) )  ~=  fwhm / 2.355
@@ -232,6 +240,10 @@ def generate_template_from_bands(centers, fwhm, params, dataset_loader, **kwargs
     slope, _, _, _ = np.linalg.lstsq(
         np.stack((np.ones_like(concentrations), concentrations)).T, lograd, rcond=None)
     spectrum = slope[1, :] * SCALING
+
+    #st, en = 0,1
+    #spectrum = (rads[en,:] - rads[st,:]).dot(response) / (concentrations[en]-concentrations[st]) * SCALING
+
     target = np.stack((np.arange(1, spectrum.shape[0]+1), centers, spectrum)).T
     return target
 


### PR DESCRIPTION
This PR adds cloud, water, flare, and saturation masking to the MF mean and covariance estimation. It also adds a field to the MF output file's header file called "fraction_of_lines_per_column_used_in_mf_mu_cov_estimation".

Testing is limited as I'm having trouble getting the set of flare cases that @pgbrodrick sent me to run. It is possible that there is a bug, but I can't seem to reproduce it and I suspect it is a ray issue. Be careful!