### PR TITLE
Explicitly import scipy.linalg submodule to prevent import errors

### DIFF
--- a/parallel_mf.py
+++ b/parallel_mf.py
@@ -24,7 +24,7 @@ import argparse
 from spectral.io import envi
 
 import sys
-import scipy
+import scipy.linalg
 import scipy.ndimage
 import numpy as np
 from utils import envi_header, write_bil_chunk


### PR DESCRIPTION
Explicitly import `scipy.linalg` submodule to prevent import errors, see: [https://github.com/scipy/scipy/issues/10284](https://github.com/scipy/scipy/issues/10284)