### PR TITLE
Add netCDF support to ghg_process

### DIFF
--- a/ghg_process.py
+++ b/ghg_process.py
@@ -27,8 +27,10 @@ import logging
 from spectral.io import envi
 import numpy as np
 import os
-from utils import envi_header
+from utils import envi_header, ReadAbstractDataSet
 from osgeo import gdal
+
+import pdb
 
 
 
@@ -124,17 +126,27 @@ def main(input_args=None):
             subprocess.call(f'rm {args.output_base}_ch4*',shell=True)
 
     if (os.path.isfile(co2_target_file) is False and args.co2) or args.overwrite or os.path.isfile(ch4_target_file) is False:
-        sza = envi.open(obs_file_hdr).open_memmap(interleave='bip')[...,4]
+        #sza = envi.open(obs_file_hdr).open_memmap(interleave='bip')[...,4]
+        sza = ReadAbstractDataSet(args.obs_file, netcdf_key = 'obs', interleave = 'bip')[...,4]
         mean_sza = np.mean(sza[sza != -9999])
 
-        elevation = envi.open(loc_file_hdr).open_memmap(interleave='bip')[...,2]
+        if args.loc_file[-3:] == '.nc':
+            elevation = ReadAbstractDataSet(args.radiance_file, netcdf_group = 'location', netcdf_key = 'elev', interleave = 'bip')
+        else:
+            elevation = envi.open(loc_file_hdr).open_memmap(interleave='bip')[...,2]
+
         mean_elevation = np.mean(elevation[elevation != -9999]) / 1000.
         mean_elevation = min(max(0, mean_elevation),3)
 
         if args.state_subs is not None:
-            state_ds = envi.open(envi_header(args.state_subs))
-            band_names = state_ds.metadata['band names']
-            h2o = state_ds.open_memmap(interleave='bip')[...,band_names.index('H2OSTR')]
+
+            if args.state_subs[-3:] == '.nc':
+                h2o = ReadAbstractDataSet(args.l2a_mask_file, netcdf_key = 'mask')[:,:,6]
+            else:
+                state_ds = envi.open(envi_header(args.state_subs))
+                band_names = state_ds.metadata['band names']
+                h2o = state_ds.open_memmap(interleave='bip')[...,band_names.index('H2OSTR')]
+
             mean_h2o = np.mean(h2o[h2o != -9999])
         else:
             # Just guess something...

--- a/ghg_process.py
+++ b/ghg_process.py
@@ -127,11 +127,11 @@ def main(input_args=None):
 
     if (os.path.isfile(co2_target_file) is False and args.co2) or args.overwrite or os.path.isfile(ch4_target_file) is False:
         #sza = envi.open(obs_file_hdr).open_memmap(interleave='bip')[...,4]
-        sza = ReadAbstractDataSet(args.obs_file, netcdf_key = 'obs', interleave = 'bip')[...,4]
+        sza = ReadAbstractDataSet(args.obs_file, netcdf_key = 'obs', envi_interleave = 'bip')[...,4]
         mean_sza = np.mean(sza[sza != -9999])
 
         if args.loc_file[-3:] == '.nc':
-            elevation = ReadAbstractDataSet(args.radiance_file, netcdf_group = 'location', netcdf_key = 'elev', interleave = 'bip')
+            elevation = ReadAbstractDataSet(args.radiance_file, netcdf_group = 'location', netcdf_key = 'elev', envi_interleave = 'bip')
         else:
             elevation = envi.open(loc_file_hdr).open_memmap(interleave='bip')[...,2]
 

--- a/ghg_process.py
+++ b/ghg_process.py
@@ -54,6 +54,8 @@ def main(input_args=None):
 
     radiance_file = args.radiance_file
     radiance_file_hdr = envi_header(radiance_file)
+    if radiance_file[-3:] == '.nc':
+        radiance_file_hdr = radiance_file
  
     obs_file = args.obs_file
     obs_file_hdr = envi_header(obs_file)

--- a/parallel_mf.py
+++ b/parallel_mf.py
@@ -78,7 +78,7 @@ def main(input_args=None):
    
     
     logging.info('Started processing input file: "%s"'%str(args.radiance_file))
-    ds = ReadAbstractDataSet(args.radiance_file, netcdf_key = 'radiance')
+    ds = ReadAbstractDataSet(args.radiance_file, netcdf_key = 'radiance', envi_interleave = 'bil')
     wavelengths = np.array([float(x) for x in ds.metadata['wavelength']])
 
     if args.wavelength_range is None:
@@ -171,10 +171,7 @@ def main(input_args=None):
         logging.debug("adding cloud / water mask")
         clouds_and_surface_water_mask = None
         if args.l2a_mask_file is not None:
-            #clouds_and_surface_water_mask = np.sum(envi.open(envi_header(args.l2a_mask_file)).open_memmap(interleave='bip')[ce:chunk_edges[_ce+1],:,:3],axis=-1) > 0
-            masks = ReadAbstractDataSet(args.l2a_mask_file)[...]
-            if masks.shape[1] == 8:
-                masks = masks.transpose((0,2,1))
+            masks = ReadAbstractDataSet(args.l2a_mask_file, netcdf_key = 'mask', envi_interleave = 'bip')[...]
             clouds_and_surface_water_mask = np.sum(masks[ce:chunk_edges[_ce+1],:,:3],axis=-1) > 0
             good_pixel_mask = np.where(clouds_and_surface_water_mask, False, good_pixel_mask)
 
@@ -367,14 +364,10 @@ def calculate_saturation_mask(bandmask_file: str, radiance: np.array, dilation_i
     excludes them.'''
 
     if chunk_edges is None:
-        #l1b_bandmask_loaded = envi.open(envi_header(bandmask_file))[:,:,:]
-        l1b_bandmask_loaded = ReadAbstractDataSet(bandmask_file, netcdf_key = 'band_mask')[:,:,:].astype(np.uint8)
+        l1b_bandmask_loaded = ReadAbstractDataSet(bandmask_file, netcdf_key = 'band_mask', envi_interleave = 'bip')[:,:,:].astype(np.uint8)
     else:
-        #l1b_bandmask_loaded = envi.open(envi_header(bandmask_file))[chunk_edges[0]:chunk_edges[1],:,:]
-        l1b_bandmask_loaded = ReadAbstractDataSet(bandmask_file, netcdf_key = 'band_mask')[chunk_edges[0]:chunk_edges[1],:,:].astype(np.uint8)
+        l1b_bandmask_loaded = ReadAbstractDataSet(bandmask_file, netcdf_key = 'band_mask', envi_interleave = 'bip')[chunk_edges[0]:chunk_edges[1],:,:].astype(np.uint8)
 
-    if np.argmin(l1b_bandmask_loaded.shape) == 1:
-        l1b_bandmask_loaded = l1b_bandmask_loaded.transpose((0,2,1))
     bad9999 = np.any(radiance < -1, axis = 1)
     l1b_bandmask_unpacked = np.unpackbits(l1b_bandmask_loaded, axis= -1)
     l1b_bandmask_summed = np.sum(l1b_bandmask_unpacked, axis = -1)

--- a/target_generation.py
+++ b/target_generation.py
@@ -18,12 +18,15 @@
 # Authors: Markus Foote
 
 # version working-6 with full modtran runs and warnings and optimizations
+from utils import ReadAbstractDataSet
+
 from os.path import exists
 import numpy as np
 import scipy.ndimage
 import argparse
 import spectral
 import h5py
+import pdb
 
 
 def check_param(value, min, max, name):
@@ -272,9 +275,9 @@ def main(input_args=None):
              'water': args.water_vapor,
              'order': args.order}
     if args.hdr and exists(args.hdr):
-        image = spectral.io.envi.open(args.hdr)
-        centers = np.array([float(x) for x in image.metadata['wavelength']])
-        fwhm = np.array([float(x) for x in image.metadata['fwhm']])
+        ds = ReadAbstractDataSet(args.hdr)
+        centers = ds.metadata['wavelength']
+        fwhm = ds.metadata['fwhm']
     elif args.txt and exists(args.txt):
         data = np.loadtxt(args.txt, usecols=(0, 1),delimiter=',')
         centers = data[:, 0]

--- a/target_generation.py
+++ b/target_generation.py
@@ -275,7 +275,7 @@ def main(input_args=None):
              'water': args.water_vapor,
              'order': args.order}
     if args.hdr and exists(args.hdr):
-        ds = ReadAbstractDataSet(args.hdr)
+        ds = ReadAbstractDataSet(args.hdr, netcdf_key = 'radiance')
         centers = ds.metadata['wavelength']
         fwhm = ds.metadata['fwhm']
     elif args.txt and exists(args.txt):

--- a/target_generation.py
+++ b/target_generation.py
@@ -275,7 +275,7 @@ def main(input_args=None):
              'water': args.water_vapor,
              'order': args.order}
     if args.hdr and exists(args.hdr):
-        ds = ReadAbstractDataSet(args.hdr, netcdf_key = 'radiance', interleave = 'bil')
+        ds = ReadAbstractDataSet(args.hdr, netcdf_key = 'radiance', envi_interleave = 'bil')
         centers = ds.metadata['wavelength']
         fwhm = ds.metadata['fwhm']
     elif args.txt and exists(args.txt):

--- a/target_generation.py
+++ b/target_generation.py
@@ -275,7 +275,7 @@ def main(input_args=None):
              'water': args.water_vapor,
              'order': args.order}
     if args.hdr and exists(args.hdr):
-        ds = ReadAbstractDataSet(args.hdr, netcdf_key = 'radiance')
+        ds = ReadAbstractDataSet(args.hdr, netcdf_key = 'radiance', interleave = 'bil')
         centers = ds.metadata['wavelength']
         fwhm = ds.metadata['fwhm']
     elif args.txt and exists(args.txt):


### PR DESCRIPTION
Adds support to ghg_process for reading both ENVI and netCDF files from the DAAC.

1. There are only 3 netCDF input files compared to 7 ENVI input files because several fields that are distant files in ENVI are combined into one netCDF file. As a result, there are redundant inputs. This could probably be streamlined, but anyway.
2. The glt file is not moved to netcdf. I wasn't sure if this should be done or not.
3. This is not as clean an implementation as I'd hoped because there are not equivalent files. For example, there is no loc netCDF file.

Example ENVI ghg_process calls:
`python ghg_process.py 
/beegfs/store/emit/ops/data/acquisitions/20230810/emit20230810t051516/l1b/emit20230810t051516_o22204_s000_l1b_rdn_b0106_v01.img /beegfs/store/emit/ops/data/acquisitions/20230810/emit20230810t051516/l1b/emit20230810t051516_o22204_s000_l1b_obs_b0106_v01.img /beegfs/store/emit/ops/data/acquisitions/20230810/emit20230810t051516/l1b/emit20230810t051516_o22204_s000_l1b_loc_b0106_v01.img /beegfs/store/emit/ops/data/acquisitions/20230810/emit20230810t051516/l1b/emit20230810t051516_o22204_s000_l1b_glt_b0106_v01.img /beegfs/store/emit/ops/data/acquisitions/20230810/emit20230810t051516/l1b/emit20230810t051516_o22204_s000_l1b_bandmask_b0106_v01.img /beegfs/store/emit/ops/data/acquisitions/20230810/emit20230810t051516/l2a/emit20230810t051516_o22204_s000_l2a_mask_b0106_v01.img /beegfs/scratch/jfahlen/test_netcdf/emit20230810t051516_envi --state_subs /beegfs/store/emit/ops/data/acquisitions/20230810/emit20230810t051516/l2a/emit20230810t051516_o22204_s000_l2a_statesubs_b0106_v01.img --overwrite`

Equivalent call using netCDF files downloaded from LP DAAC:
`python ghg_process.py /beegfs/scratch/jfahlen/test_netcdf/EMIT_L1B_RAD_001_20230810T051516_2322204_013.nc /beegfs/scratch/jfahlen/test_netcdf/EMIT_L1B_OBS_001_20230810T051516_2322204_013.nc /beegfs/scratch/jfahlen/test_netcdf/EMIT_L1B_RAD_001_20230810T051516_2322204_013.nc /beegfs/store/emit/ops/data/acquisitions/20230810/emit20230810t051516/l1b/emit20230810t051516_o22204_s000_l1b_glt_b0106_v01.img /beegfs/scratch/jfahlen/test_netcdf/EMIT_L2A_MASK_001_20230810T051516_2322204_013.nc /beegfs/scratch/jfahlen/test_netcdf/EMIT_L2A_MASK_001_20230810T051516_2322204_013.nc /beegfs/scratch/jfahlen/test_netcdf/emit20230810t051516 --state_subs /beegfs/scratch/jfahlen/test_netcdf/EMIT_L2A_MASK_001_20230810T051516_2322204_013.nc --overwrite`